### PR TITLE
feat: add configurable base URL for test environment support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ website/node_modules
 
 website/vendor
 
+# Don't check in the binary files
+terraform-provider-cscdm
+
 # Test exclusions
 !command/test-fixtures/**/*.tfstate
 !command/test-fixtures/**/.terraform/

--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ resource "cscdm_record" "www_example_com" {
 }
 ```
 
+To use the CSC Test environment
+```hcl
+provider "cscdm" {
+    ...
+
+    # This provider supports setting the base url for test environment usage via
+    # the field below or with the `CSCDM_BASE_URL` environment variable
+    base_url = "https://apis-ote.cscglobal.com/dbs/api/v2/"
+}
+```
+
 ## Development Requirements
 
 - [Terraform](https://developer.hashicorp.com/terraform/downloads) >= 1.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,3 +27,4 @@ provider "cscdm" {
 
 - `api_key` (String, Sensitive) CSC Domain Manager API Key
 - `api_token` (String, Sensitive) CSC Domain Manager API Token
+- `base_url` (String) CSC Domain Manager API Base URL. Defaults to CSC Production API (https://apis.cscglobal.com/dbs/api/v2/)

--- a/internal/cscdm/common_test.go
+++ b/internal/cscdm/common_test.go
@@ -1,0 +1,4 @@
+package cscdm_test
+
+// Shared test constants for cscdm package tests.
+const testBaseURL = "https://test.example.com/api/v2/"

--- a/internal/cscdm/cscdm.go
+++ b/internal/cscdm/cscdm.go
@@ -12,10 +12,9 @@ import (
 )
 
 const (
-	CSC_DOMAIN_MANAGER_API_URL = "https://apis.cscglobal.com/dbs/api/v2/"
-	POLL_INTERVAL              = 5 * time.Second
-	FLUSH_IDLE_DURATION        = 5 * time.Second
-	HTTP_REQUEST_TIMEOUT       = 30 * time.Second
+	POLL_INTERVAL        = 5 * time.Second
+	FLUSH_IDLE_DURATION  = 5 * time.Second
+	HTTP_REQUEST_TIMEOUT = 30 * time.Second
 )
 
 type Client struct {
@@ -36,11 +35,11 @@ type Client struct {
 	cacheMutex sync.RWMutex
 }
 
-func (c *Client) Configure(apiKey string, apiToken string) {
+func (c *Client) Configure(apiKey string, apiToken string, baseUrl string) {
 	c.http = &http.Client{
 		Timeout: HTTP_REQUEST_TIMEOUT,
 		Transport: &util.HttpTransport{
-			BaseUrl: CSC_DOMAIN_MANAGER_API_URL,
+			BaseUrl: baseUrl,
 			Headers: map[string]string{
 				"accept":        "application/json",
 				"apikey":        apiKey,

--- a/internal/cscdm/cscdm_flush_fix_test.go
+++ b/internal/cscdm/cscdm_flush_fix_test.go
@@ -43,7 +43,7 @@ func testGoroutineLeaks(t *testing.T) {
 	// Test that multiple client create/stop cycles work without accumulating issues
 	for cycle := 0; cycle < 5; cycle++ {
 		client := &cscdm.Client{}
-		client.Configure("test-key", "test-token")
+		client.Configure("test-key", "test-token", testBaseURL)
 
 		// Let it run briefly
 		time.Sleep(20 * time.Millisecond)
@@ -77,7 +77,7 @@ func testGoroutineLeaks(t *testing.T) {
 
 func testErrorResilience(t *testing.T) {
 	client := &cscdm.Client{}
-	client.Configure("invalid-key", "invalid-token") // Force API errors
+	client.Configure("invalid-key", "invalid-token", testBaseURL) // Force API errors
 
 	initialGoroutines := runtime.NumGoroutine()
 
@@ -111,7 +111,7 @@ func testErrorResilience(t *testing.T) {
 
 func testConcurrentAccess(t *testing.T) {
 	client := &cscdm.Client{}
-	client.Configure("test-key", "test-token")
+	client.Configure("test-key", "test-token", testBaseURL)
 
 	var wg sync.WaitGroup
 
@@ -141,7 +141,7 @@ func testConcurrentAccess(t *testing.T) {
 
 func testGracefulShutdown(t *testing.T) {
 	client := &cscdm.Client{}
-	client.Configure("test-key", "test-token")
+	client.Configure("test-key", "test-token", testBaseURL)
 
 	// Start background work
 	stop := make(chan bool)
@@ -184,7 +184,7 @@ func testGracefulShutdown(t *testing.T) {
 
 func testMultipleStops(t *testing.T) {
 	client := &cscdm.Client{}
-	client.Configure("test-key", "test-token")
+	client.Configure("test-key", "test-token", testBaseURL)
 
 	// Let client initialize
 	time.Sleep(10 * time.Millisecond)

--- a/internal/cscdm/cscdm_goroutine_test.go
+++ b/internal/cscdm/cscdm_goroutine_test.go
@@ -17,7 +17,7 @@ func TestClient_GoroutineLeakPrevention(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		client := &cscdm.Client{}
-		client.Configure("test-key", "test-token")
+		client.Configure("test-key", "test-token", testBaseURL)
 		clients[i] = client
 
 		// Allow goroutines to start
@@ -50,7 +50,7 @@ func TestClient_GoroutineLeakPrevention(t *testing.T) {
 
 	// Test that we can create and stop another client without issues
 	testClient := &cscdm.Client{}
-	testClient.Configure("test-key", "test-token")
+	testClient.Configure("test-key", "test-token", testBaseURL)
 
 	done := make(chan bool, 1)
 	go func() {
@@ -69,7 +69,7 @@ func TestClient_GoroutineLeakPrevention(t *testing.T) {
 func TestClient_FlushErrorResilience(t *testing.T) {
 	// This test verifies that the flush loop continues running even after errors
 	client := &cscdm.Client{}
-	client.Configure("invalid-key", "invalid-token") // Force API errors
+	client.Configure("invalid-key", "invalid-token", testBaseURL) // Force API errors
 
 	initialGoroutines := runtime.NumGoroutine()
 
@@ -102,7 +102,7 @@ func TestClient_FlushErrorResilience(t *testing.T) {
 
 func TestClient_ConcurrentFlushTriggers(t *testing.T) {
 	client := &cscdm.Client{}
-	client.Configure("test-key", "test-token")
+	client.Configure("test-key", "test-token", testBaseURL)
 
 	initialGoroutines := runtime.NumGoroutine()
 
@@ -145,7 +145,7 @@ func TestClient_ConcurrentFlushTriggers(t *testing.T) {
 
 func TestClient_GracefulShutdown(t *testing.T) {
 	client := &cscdm.Client{}
-	client.Configure("test-key", "test-token")
+	client.Configure("test-key", "test-token", testBaseURL)
 
 	// Start multiple goroutines that trigger flushes
 	stopWorkers := make(chan bool)
@@ -191,7 +191,7 @@ func TestClient_GracefulShutdown(t *testing.T) {
 
 func TestClient_TriggerChannelDraining(t *testing.T) {
 	client := &cscdm.Client{}
-	client.Configure("test-key", "test-token")
+	client.Configure("test-key", "test-token", testBaseURL)
 
 	// Let the client run for a bit to test the flush loop
 	time.Sleep(50 * time.Millisecond)
@@ -216,7 +216,7 @@ func TestClient_TriggerChannelDraining(t *testing.T) {
 
 func TestClient_StopChannelCleanup(t *testing.T) {
 	client := &cscdm.Client{}
-	client.Configure("test-key", "test-token")
+	client.Configure("test-key", "test-token", testBaseURL)
 
 	// Let the client run for a bit
 	time.Sleep(10 * time.Millisecond)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -39,6 +39,7 @@ type CscDomainManagerProvider struct {
 type CscDomainManagerProviderModel struct {
 	ApiKey   types.String `tfsdk:"api_key"`
 	ApiToken types.String `tfsdk:"api_token"`
+	BaseUrl  types.String `tfsdk:"base_url"`
 }
 
 // Metadata returns the provider type name.
@@ -60,6 +61,10 @@ func (p *CscDomainManagerProvider) Schema(_ context.Context, _ provider.SchemaRe
 				Description: "CSC Domain Manager API Token",
 				Optional:    true,
 				Sensitive:   true,
+			},
+			"base_url": schema.StringAttribute{
+				Description: fmt.Sprintf("CSC Domain Manager API Base URL. Defaults to CSC Production API (%s)", CSC_DOMAIN_MANAGER_API_URL),
+				Optional:    true,
 			},
 		},
 	}
@@ -103,6 +108,10 @@ func (p *CscDomainManagerProvider) Configure(ctx context.Context, req provider.C
 	// with Terraform configuration value if set.
 	apiKey := os.Getenv("CSCDM_API_KEY")
 	apiToken := os.Getenv("CSCDM_API_TOKEN")
+	baseUrl := os.Getenv("CSCDM_BASE_URL")
+	if baseUrl == "" {
+		baseUrl = CSC_DOMAIN_MANAGER_API_URL
+	}
 
 	if !config.ApiKey.IsNull() {
 		apiKey = config.ApiKey.ValueString()
@@ -110,6 +119,10 @@ func (p *CscDomainManagerProvider) Configure(ctx context.Context, req provider.C
 
 	if !config.ApiToken.IsNull() {
 		apiToken = config.ApiToken.ValueString()
+	}
+
+	if !config.BaseUrl.IsNull() {
+		baseUrl = config.BaseUrl.ValueString()
 	}
 
 	// If any of the expected configurations are missing, return
@@ -144,7 +157,7 @@ func (p *CscDomainManagerProvider) Configure(ctx context.Context, req provider.C
 
 	// Make HTTP client available during DataSource and Resource Configure methods.
 	http := &http.Client{Transport: &util.HttpTransport{
-		BaseUrl: CSC_DOMAIN_MANAGER_API_URL,
+		BaseUrl: baseUrl,
 		Headers: map[string]string{
 			"accept":        "application/json",
 			"apikey":        apiKey,
@@ -153,7 +166,7 @@ func (p *CscDomainManagerProvider) Configure(ctx context.Context, req provider.C
 	}}
 
 	client := &cscdm.Client{}
-	client.Configure(apiKey, apiToken)
+	client.Configure(apiKey, apiToken, baseUrl)
 
 	resp.DataSourceData = http
 	resp.ResourceData = client


### PR DESCRIPTION
Fixes #33

- Add optional `base_url` provider configuration attribute
- Support `CSCDM_BASE_URL` environment variable override
- Default to CSC Production API URL (https://apis.cscglobal.com/dbs/api/v2/)
- Update Client.Configure() to accept baseUrl parameter
- Add shared test constant for test environment URL
- Update all client instantiations in tests to use configurable base URL
- Auto-generate schema documentation with default URL reference

This enables users to point the provider at different API environments (production, test/OTE) via configuration, environment variable, or code. Configuration precedence: environment variable → config file → default.

BREAKING CHANGE: Client.Configure() signature changed from 2 to 3 parameters. This is only a breaking change for internal package users; provider users experience no breaking changes (base_url is optional with sensible default).
