### PR TITLE
fix: Add pagination for long zone lists (>1000)

### DIFF
--- a/internal/provider/zones_data_source.go
+++ b/internal/provider/zones_data_source.go
@@ -340,20 +340,26 @@ func (d *ZonesDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		}
 		state.Zones = append(state.Zones, convertZone(zoneJson))
 	} else {
-		var zonesJson ZonesJson
-		zonesResp, err := d.client.Get("zones")
-		if err != nil {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read zones, got error: %s", err))
-			return
-		}
-		defer zonesResp.Body.Close()
-		err = json.NewDecoder(zonesResp.Body).Decode(&zonesJson)
-		if err != nil {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to unmarshal zones, got error: %s", err))
-			return
-		}
-		for _, zone := range zonesJson.Zones {
-			state.Zones = append(state.Zones, convertZone(zone))
+		for page := int64(1); ; page++ {
+			var zonesJson ZonesJson
+			zonesResp, err := d.client.Get(fmt.Sprintf("zones?page=%d", page))
+			if err != nil {
+				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read zones, got error: %s", err))
+				return
+			}
+			err = json.NewDecoder(zonesResp.Body).Decode(&zonesJson)
+			if err != nil {
+				zonesResp.Body.Close()
+				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to unmarshal zones, got error: %s", err))
+				return
+			}
+			zonesResp.Body.Close()
+			for _, zone := range zonesJson.Zones {
+				state.Zones = append(state.Zones, convertZone(zone))
+			}
+			if page >= zonesJson.Meta.Pages {
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
This pull request improves the way zones are fetched in the `ZonesDataSource` by adding support for paginated API responses. Instead of retrieving all zones in a single request, the code now iterates through each page of results, ensuring all zones are collected regardless of the total count.

**API Pagination Support:**

* Updated the logic in the `Read` method of `zones_data_source.go` to loop through API pages using a `for` loop and the `zones?page=%d` endpoint, collecting zones from each page until all are fetched.
* Ensured proper closing of response bodies after decoding JSON to prevent resource leaks.
* Added a break condition when the last page is reached, based on the `Meta.Pages` field in the API response.



**Testing:**
There is no testing framework for this portion of the code, so I was unable to add tests to specifically exercise this new code.  I did however test it as a dev override against our prod env which needs it, and it works as expected.



Fixes #39 
